### PR TITLE
Change message-header-name face

### DIFF
--- a/doom-one-theme.el
+++ b/doom-one-theme.el
@@ -356,7 +356,8 @@
      `(org-checkbox-statistics-todo ((,c (:inherit org-todo))))
      `(org-checkbox-statistics-done ((,c (:inherit org-done))))
      ;; Custom org-mode faces
-     `(org-list-bullet           ((,c (:foreground ,cyan)))))
+     `(org-list-bullet           ((,c (:foreground ,cyan))))
+     `(message-header-name ((,c (:foreground ,green)))))
 
     (custom-theme-set-variables
      'doom-one


### PR DESCRIPTION
Before:
![mail_1](https://cloud.githubusercontent.com/assets/1313584/18340050/2b74a67c-75a3-11e6-91e6-4378f17a377f.png)

After:
![header_0](https://cloud.githubusercontent.com/assets/1313584/18340058/3409ea2c-75a3-11e6-859b-7c4d7daefc9d.png)

tbh I don’t actually care about `message-header-name` but about `mu4e-header-key-face` which inherits from it. Setting `message-header-name` should help other mail clients but I haven’t tested any.

