### PR TITLE
Basic support for tabbar

### DIFF
--- a/doom-one-theme.el
+++ b/doom-one-theme.el
@@ -278,7 +278,7 @@
      `(tabbar-default              ((,c (:foreground ,bg-d :background ,bg-d :height 0.9))))
      `(tabbar-modified             ((,c (:inherit 'tabbar-default :foreground "#712222" :bold ,bold))))
      `(tabbar-unselected           ((,c (:inherit 'tabbar-default :foreground ,modeline-fg-inactive))))
-     `(tabbar-selected             ((,c (:inherit 'tabbar-default :foreground ,modeline-fg :bold ,bold))))
+     `(tabbar-selected             ((,c (:inherit 'tabbar-default :foreground ,modeline-fg :background ,bg :bold ,bold))))
      `(tabbar-selected-modified    ((,c (:inherit 'tabbar-selected :foreground "PaleGreen3"))))
      `(tabbar-highlight            ((,c (:foreground ,fg :background ,bg-d :inverse-video t))))
      `(tabbar-button               ((,c (:foreground ,modeline-fg :background ,modeline-bg-inactive))))

--- a/doom-one-theme.el
+++ b/doom-one-theme.el
@@ -274,6 +274,15 @@
      ;; pos-tip
      `(popup                       ((,c (:inherit tooltip))))
      `(popup-tip-face              ((,c (:inherit tooltip))))
+     ;; tabbar
+     `(tabbar-default              ((,c (:foreground ,bg-d :background ,bg-d :height 0.9))))
+     `(tabbar-modified             ((,c (:inherit 'tabbar-default :foreground "#712222" :bold ,bold))))
+     `(tabbar-unselected           ((,c (:inherit 'tabbar-default :foreground ,modeline-fg-inactive))))
+     `(tabbar-selected             ((,c (:inherit 'tabbar-default :foreground ,modeline-fg :bold ,bold))))
+     `(tabbar-selected-modified    ((,c (:inherit 'tabbar-selected :foreground "PaleGreen3"))))
+     `(tabbar-highlight            ((,c (:foreground ,fg :background ,bg-d :inverse-video t))))
+     `(tabbar-button               ((,c (:foreground ,modeline-fg :background ,modeline-bg-inactive))))
+     `(tabbar-button-highlight     ((,c (:inherit 'tabbar-button :inverse-video t))))
      ;; swiper
      `(swiper-line-face            ((,c (:background ,blue    :foreground ,black))))
      `(swiper-match-face-1         ((,c (:background ,black   :foreground ,grey))))


### PR DESCRIPTION
This pr fixes the colors that [tabbar](https://melpa.org/#/tabbar) uses for doom-one. More customization is needed to make it look better (spacing in the tabs, changing the default ugly icons, etc.) but I don't know if these belong in doom-one.

Here's a screenshot:
![tabbar-doom-one](https://cloud.githubusercontent.com/assets/1548327/20449559/731b86ba-adea-11e6-995e-0f9a668ebe85.png)
