### PR TITLE
Support which-function-mode

### DIFF
--- a/doom-one-theme.el
+++ b/doom-one-theme.el
@@ -334,6 +334,8 @@
      `(reb-match-1 ((,c (:foreground ,magenta  :inverse-video t))))
      `(reb-match-2 ((,c (:foreground ,green    :inverse-video t))))
      `(reb-match-3 ((,c (:foreground ,yellow   :inverse-video t))))
+     ;; which-func
+     `(which-func                           ((,c (:foreground ,blue))))
      ;; which-key
      `(which-key-key-face                   ((,c (:foreground ,green))))
      `(which-key-group-description-face     ((,c (:foreground ,violet))))


### PR DESCRIPTION
Without this it’s sadly almost unreadable. I don’t really care which color in particular is chosen as long as it’s readable so if you have any better suggestions I’m all ears.

*before*
![doom_which_func](https://cloud.githubusercontent.com/assets/1313584/23084361/324b4548-f562-11e6-963f-51ec40a93fcc.png)
*after*
![doom_which_func_2](https://cloud.githubusercontent.com/assets/1313584/23084401/64f8752e-f562-11e6-9cdc-d7f4df6a7fe9.png)
