### PR TITLE
change forground of swiper matches to black for better contrast

### DIFF
--- a/doom-themes-common.el
+++ b/doom-themes-common.el
@@ -393,9 +393,9 @@
      ;; swiper
      (swiper-line-face    :background blue    :foreground black)
      (swiper-match-face-1 :background black   :foreground light-grey)
-     (swiper-match-face-2 :background orange  :foreground fg :bold bold)
-     (swiper-match-face-3 :background magenta :foreground fg :bold bold)
-     (swiper-match-face-4 :background green   :foreground fg :bold bold)
+     (swiper-match-face-2 :background orange  :foreground black :bold bold)
+     (swiper-match-face-3 :background magenta :foreground black :bold bold)
+     (swiper-match-face-4 :background green   :foreground black :bold bold)
 
      ;; tabbar
      (tabbar-default           :foreground bg-alt :background bg-alt :height 0.9)


### PR DESCRIPTION
Change the foreground of swiper matches to black to allow for better contrast and visibility.

Before:

![swiper-matches-before](http://drop.bryan.codes/mlzApYvHL4.png)

After:

![swiper-matches-after](http://drop.bryan.codes/J3INUoER1I.png)

After (molokai):

![swiper-matches-after-molokai](http://drop.bryan.codes/tzQmbKv1dR.png)