### PR TITLE
Add lsp faces

### DIFF
--- a/doom-themes-common.el
+++ b/doom-themes-common.el
@@ -441,6 +441,11 @@ Faces in EXTRA-FACES override the default faces."
        ;; nlinum-relative
        (nlinum-relative-current-face :inherit 'doom-linum-highlight)
 
+       ;; lsp
+       (lsp-face-highlight-textual :background dark-blue :foreground white :distant-foreground black :bold bold)
+       (lsp-face-hightlight-read   :background dark-blue :foreground white :distant-foreground black :bold bold)
+       (lsp-face-hightlight-write  :background dark-blue :foreground white :distant-foreground black :bold bold)
+
        ;; magit
        (magit-bisect-bad        :foreground red)
        (magit-bisect-good       :foreground green)


### PR DESCRIPTION
My attempt to add faces for the language server protocol [1], which currently are:

  - lsp-face-highlight-textual
      "textual occurances of symbols."
      default: yellow background

  - lsp-face-hightlight-read
      "highlighting symbols being read."
      default: red background

  - lsp-face-hightlight-write
      "highlighting symbols being written to."
      default: green background

[1] https://github.com/emacs-lsp/lsp-mode

The yellow looked completely out of place so I used the colors use for incremental search; if you have a better idea for what color, I don't mind. ;)

NB: there seems to a type in hightlight for -read, -write. I have opened an upstream issue emacs-lsp/lsp-mode#89 about it, so these might change. Also I just used the same colors for read and write, which might also not be the best, but it is a start I guess.
