### PR TITLE
Sync lsp faces names with upstream

### DIFF
--- a/doom-themes-common.el
+++ b/doom-themes-common.el
@@ -444,8 +444,8 @@ Faces in EXTRA-FACES override the default faces."
 
        ;; lsp
        (lsp-face-highlight-textual :background dark-blue :foreground white :distant-foreground black :bold bold)
-       (lsp-face-hightlight-read   :background dark-blue :foreground white :distant-foreground black :bold bold)
-       (lsp-face-hightlight-write  :background dark-blue :foreground white :distant-foreground black :bold bold)
+       (lsp-face-highlight-read    :background dark-blue :foreground white :distant-foreground black :bold bold)
+       (lsp-face-highlight-write   :background dark-blue :foreground white :distant-foreground black :bold bold)
 
        ;; magit
        (magit-bisect-bad        :foreground red)


### PR DESCRIPTION
The typos (hightlight) got fixed upstream. So we need to adapt.

I was tempted to change the faces for -read and -write to the something like magit-diff-added-highlight and magit-diff-removed-highlight, since the original color for the faces were green and red, but I couldnt find a way to trigger the faces so I left them as is for now.